### PR TITLE
Allow nth = -1 to select the last element in _nth method

### DIFF
--- a/lib/common/models/optional_model.dart
+++ b/lib/common/models/optional_model.dart
@@ -478,6 +478,7 @@ class Optional {
   /// Transformation: nth
   Object? _nth(Object data, bool debug) {
     if (nth == null || data is! List) return null;
+    if (nth == -1) return data.isNotEmpty ? data.last : null;
     if (nth! < 0 || nth! >= data.length) return null;
     return data[nth!];
   }


### PR DESCRIPTION
currently we can easily use n=0 to select the first element. it would be useful to use -1 as to get the last element of a list.